### PR TITLE
add first design

### DIFF
--- a/_api/apicarto.md
+++ b/_api/apicarto.md
@@ -5,6 +5,8 @@ doc_tech: https://apicarto.sgmap.fr/apidoc
 domain: http://apicarto.ign.fr
 owner: IGN
 type: reference
+additional_css: api
+
 ---
 
 L’API Carto est une brique logicielle offrant des webservices de traitements et de calculs, facilement intégrables dans les interfaces avec les usagers des services publics (front offices) reposant sur un ensemble de données géographiques de référence détenues par différents organismes.

--- a/_api/apiparticulier.md
+++ b/_api/apiparticulier.md
@@ -1,39 +1,42 @@
 ---
-name: API Particuliers
+name: API Particulier
 tagline: Simplifiez les démarches de vos usagers, ne demandez plus de justificatifs
 doc_tech: https://apiparticulier.sgmap.fr/tech
+access_link: https://apiparticulier.sgmap.fr/#/registration
 domain: https://apiparticulier.sgmap.fr
 owner: DINSIC
 type: confidential
+additional_css: api
+
 ---
 
 
-Ne plus demander de pièces justificatives inutiles
--------------------------------------------------
+## Ne plus demander de pièces justificatives inutiles
+{:.ui .header}
 
 Limiter les demandes des pièces justificatives ou informations lorsqu’elles sont détenues par d’autres administrations ( CAF, DGFIP, Pôle Emploi…).
 
 Limiter le risque de fraude documentaire en récupérant des informations certifiées à la source dans un point d'accès unique.
 
 
-Accéder aux données de façon sécurisée
---------------------------------------
+## Accéder aux données de façon sécurisée
+{:.ui .header}
 
 L'accès aux données est réalisé au travers de protocoles de communications sécurisés et seuls les opérateurs agréés peuvent se connecter à l'API.
 
 Pour obtenir un agrément, vous devez justifier d'une simplification pour les citoyens, et vous engager à n'accéder aux données personnelles qu'avec *l'accord explicite de l'usager*.
 
 
-Comprendre la différence avec FranceConnect
--------------------------------------------
+## Comprendre la différence avec FranceConnect
+{:.ui .header}
 
 API Particulier et FranceConnect sont deux systèmes indenpendants mais complémentaires.
 
 |                | FranceConnect                                | API Particulier                                                           |
 |----------------|----------------------------------------------|---------------------------------------------------------------------------|
 | Nature         | fournisseur d'identité et tiers de confiance | fournisseur données                                                       |
-| Identification | Citoyen et Fournisseur de donnée             | Fournisseur de service                                                    |
+| Identification | Citoyen et Fournisseur de service            | Fournisseur de service                                                    |
 | Type de donnée | liée à la personne                           | liée à la personne, liée au foyer familial, liée aus parents, aux enfants |
-
+{:.ui .celled .table}
 
 API Particulier et FranceConnect peuvent être utilisés seul ou conjointement.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,6 +23,7 @@
   <link rel="stylesheet" type="text/css" class="ui" href="//oss.maxcdn.com/semantic-ui/2.1.8/components/divider.min.css">
   <link rel="stylesheet" type="text/css" class="ui" href="//oss.maxcdn.com/semantic-ui/2.1.8/components/card.min.css">
   <link rel="stylesheet" type="text/css" class="ui" href="//oss.maxcdn.com/semantic-ui/2.1.8/components/label.min.css">
+  <link rel="stylesheet" type="text/css" class="ui" href="//oss.maxcdn.com/semantic-ui/2.1.8/components/table.min.css">
 
   {% if page.additional_css %}
     <link rel="stylesheet" type="text/css" href="{{ "/css/" | append: page.additional_css | append: ".css" | prepend: site.baseurl }}">

--- a/_layouts/api.html
+++ b/_layouts/api.html
@@ -2,17 +2,34 @@
 layout: default
 ---
 
-<div class="ui container">
-  <h1>{{ page.name }}</h1>
+<section id="mission-statement" class="ui vertical center aligned segment {{ page.type }}">
 
-  <h2>{{ page.tagline }}</h2>
+  <div class="ui text container">
+    <h1 class="ui inverted header">
+      {{ page.name }}
+    </h1>
+    <h2 class="ui inverted header">
+      {{ page.tagline }}
+    </h2>
 
-  <p>
-    <a href="{{ page.domain }}">Description</a>
-  </p>
-  <p>
-      <a href="{{ page.doc_tech }}">Tech</a>
-  </p>
+		<a class="ui big orange inverted button" href="#description">Découvrez comment&nbsp;&nbsp;⬇︎</a>
+  </div>
 
+</section>
+
+<div id="description" class="ui text container">
   {{ content }}
 </div>
+
+<section id="call2action" class="ui vertical center aligned segment {{ page.type }}">
+    <a class="large ui inverted yellow button" href="{{ page.doc_tech }}">
+      Documentation technique &nbsp;&nbsp;
+      <i class="code icon"></i>
+    </a>
+    {% if page.access_link %}
+    <a class="large ui inverted teal button" href="{{ page.access_link }}">
+      Demander l'accès &nbsp;&nbsp;
+      <i class="ticket icon"></i>
+    </a>
+    {% endif %}
+</section>

--- a/css/api.css
+++ b/css/api.css
@@ -1,0 +1,47 @@
+#mission-statement {
+  padding-top: 5%;
+  padding-bottom: 5%;
+  margin-bottom: 2%;
+}
+
+#mission-statement h1 {
+	padding: .2em 0;
+
+	font-size: 200%;
+	line-height: 1.8;
+	letter-spacing: .08em;
+
+	text-transform: uppercase;
+}
+
+#mission-statement h2 {
+	padding: .2em 0;
+
+	font-size: 150%;
+	line-height: 1.4;
+	letter-spacing: .05em;
+
+	text-transform: uppercase;
+}
+
+#mission-statement.confidential, #call2action.confidential{
+  background-color: #460E0E;
+}
+
+#mission-statement.reference, #call2action.reference{
+  background-color: #380E46;
+}
+
+#mission-statement.simulation, #call2action.simulation{
+  background-color: #0E1F46;
+}
+
+#mission-statement.smartData, #call2action.smartData{
+  background-color: #46320E;
+}
+
+#call2action {
+  margin-top: 2%;
+  padding-top: 2%;
+  padding-bottom: 2%;
+}

--- a/css/catalog.css
+++ b/css/catalog.css
@@ -2,15 +2,24 @@
   background-color: #0E1546;
 }
 
-.tag.label.reference {
-  background-color: #CC3636;
+.tag.label {
   color: white;
 }
 
+.tag.label.smartData {
+  background-color: #46320E;
+}
 
 .tag.label.confidential {
-  background-color: #2828B1;
-  color: white;
+  background-color: #460E0E;
+}
+
+.tag.label.reference {
+  background-color: #380E46;
+}
+
+.tag.label.simulation {
+  background-color: #0E1F46;
 }
 
 #apiButton {


### PR DESCRIPTION
Donc le résultat est disponible ici [http://www.thibautgery.com/api.gouv.fr](http://www.thibautgery.com/api.gouv.fr/api/apiparticulier.html) Vous en pensez quoi ? (j'ai repris la page d'API Particulier)

J'ai introduit un code couleur pour chaque catégorie, pour ça colle avec le reste il faut qu'elles soient sombres (elle ne demande qu'à changer)

Pour le style de documentation en elle meme j'ai utilisé le [syntaxe de kramdown](http://kramdown.gettalong.org/syntax.html) et j'ai ajouté des classes CSS dans le markdown mais du coup on commence à mélanger du style avec le contenu (je suis pas fan). Avec un bon `contributing.md` on peut le documenter facilement car c'est pas super intrusif non plus ([example](https://github.com/sgmap/api.gouv.fr/blob/designAPI/_api/apiparticulier.md))

L'autre solution est de proposer de personaliser le markdown au rendu mais vu qu'on peut pas le faire coté serveur, on a deux solutions :
 * On sort de github pages (pas encore temps je pense)
 * On le fait coté client avec la [bonne lib](https://github.com/chjj/marked) mais ça nouoblige à avoir un deuxième fichier markdown :-'(

