### PR TITLE
Changement de l'UI pour les réutilisations

### DIFF
--- a/css/homepage.scss
+++ b/css/homepage.scss
@@ -96,7 +96,7 @@ $border-type-color: #eff3f6;
     padding: 5%;
     div {
       overflow: hidden;
-      height: 15rem;
+      height: 15em;
       img {
         max-width: 100%;
         height: auto;

--- a/css/homepage.scss
+++ b/css/homepage.scss
@@ -92,6 +92,17 @@ $border-type-color: #eff3f6;
       margin: 1em auto;
       font-size: 150%;
   }
+  .ui.cards>.card>.image {
+    padding: 5%;
+    div {
+      overflow: hidden;
+      height: 15rem;
+      img {
+        max-width: 100%;
+        height: auto;
+      }
+    }
+  }
 }
 
 #apiButton {

--- a/index.html
+++ b/index.html
@@ -101,7 +101,9 @@ services:
     {% for service in page.services %}
     <div class="ui card">
       <div class="image">
-        <img src="{{ site.baseurl }}/img/{{ service.screenshot }}" alt="{{ service.name }} screenshot">
+        <div>
+          <img src="{{ site.baseurl }}/img/{{ service.screenshot }}" alt="{{ service.name }} screenshot">
+        </div>
       </div>
       <div class="content">
         <a class="header" href="{{ service.url }}">{{ service.name }}</a>


### PR DESCRIPTION
Le rendu est le suivant ; ![newuiservice](https://cloud.githubusercontent.com/assets/5861569/13528962/c5686426-e219-11e5-97c2-3efb578aaf17.png)

On force taille de l'image avec un buffer overflow (sans la déformer)

TODO:
 * refaire des screenshots plus "verticaux" pour la partie responsive