### PR TITLE
API RVA Rennes Métropole

### DIFF
--- a/_api/rennes_api-rva.md
+++ b/_api/rennes_api-rva.md
@@ -1,0 +1,70 @@
+---
+name: API RVA Rennes Métropole
+tagline: "API sur les données voies et adresses de Rennes Métropole"
+doc_tech: http://rva.data.rennes-metropole.fr/documentation.php
+domain: http://rva.data.rennes-metropole.fr/
+contract: OUVERT
+restriction: nécessite de s'enregistrer
+clients:
+  - particuliers
+  - entreprises
+  - collectivités
+partners:
+  - Keolis Rennes
+owner: Rennes Métropole
+stat: -
+category: reference
+keywords:
+  - voie
+  - adresse
+additional_css: api
+---
+
+# Présentation
+
+Rennes Métropole dispose depuis 2013 d'un Référentiel Voies et Adresses (RVA) sur les communes de l’agglomération. Ce lot de données rassemble les voies, les tronçons de voies et les adresses des 43 communes de Rennes Métropole.
+
+Le RVA a pour ambition d’être la base de données voies et adresses la plus fiable sur le territoire de Rennes Métropole.
+
+En plus des données disponibles sous forme de fichiers sur cette page, Rennes Métropole met ici à disposition les données du RVA sous la forme d’une API afin de faciliter la réutilisation des données voies et adresses de Rennes Métropole dans des applications.
+
+
+# Conditions d’utilisation
+## Modalités d’accès
+Votre inscription est nécessaire pour accéder à l’API et l’utiliser. Une clé unique vous est ainsi attribuée. Il vous est interdit de la communiquer à des tiers.
+
+Les informations fournies ne serviront qu’à des fins de statistiques et de surveillance du service et d’information sur les évolutions du service.
+
+## Licence des données
+Les données fournies au travers de la présente API sont sous licence ODbL.
+
+Les utilisateurs de l’API RVA acceptent donc les termes cette licence dans le cadre de la réutilisation des données accessibles via ce site / ce service.
+
+## Garantie de disponibilité et support
+
+Rennes Métropole met en œuvre les moyens qu’elle juge nécessaires pour garantir le bon fonctionnement de l’API (disponibilité, temps de réponse). Rennes Métropole se réserve le droit d’interrompre de manière temporaire ou définitive de ce site / ce service.
+
+Ce service de données est fourni « comme tel ». En aucun cas Rennes Métropole ne peut être tenue responsable des dommages directs ou indirects liés à l’utilisation, conforme ou non conforme, des données fournies via ce site / ce service ou de l’interruption temporaire ou définitive du site / du service.
+
+## Mise en cache des données
+
+La mise en cache des données fournies au travers de ce site / ce service est strictement interdit. Des fichiers sont disponibles au téléchargement pour un usage hors-ligne sur [cette page](http://www.data.rennes-metropole.fr/les-donnees/catalogue/?tx_icsopendatastore_pi1%5buid%5d=217).
+
+Un stockage immédiat, automatique, et temporaire de données en vue d’améliorer la performance de fonctionnement des applications utilisant les données fournies par ce site / ce service, pendant la seule durée de connexion de l’utilisateur final, est cependant autorisé.
+
+## Inscription
+
+Merci de lire les conditions d'utilisation avant de vous inscrire [en cliquant ici](http://rva.data.rennes-metropole.fr/inscription.php).
+
+
+## Aller plus loin
+
+Reportez-vous à la [documentation de l’API](http://rva.data.rennes-metropole.fr/documentation.php) ainsi qu’aux métadonnées disponibles.
+
+L’API ne vous suffit pas ? Contactez-nous pour envisager ensemble les évolutions nécessaires.
+
+
+
+
+
+


### PR DESCRIPTION
ajout de l'API RVA Rennes Métropole à https://api.beta.gouv.fr/api/reference