### PR TITLE
Update add pages

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
             <div class="item">
               <i class="add icon"></i>
               <div class="content">
-                <a href="https://thibaut6.typeform.com/to/dfwyyt" target="_blank">Ajouter une API</a>
+                <a href="{{ site.baseurl }}/ajouter-une-api.html" target="_blank">Ajouter une API</a>
               </div>
             </div>
             <div class="item">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,13 +7,13 @@
             <div class="item">
               <i class="add icon"></i>
               <div class="content">
-                <a href="{{ site.baseurl }}/ajouter-une-api.html" target="_blank">Ajouter une API</a>
+                <a href="{{ site.baseurl }}/ajouter-une-api.html">Ajouter une API</a>
               </div>
             </div>
             <div class="item">
               <i class="rocket icon"></i>
               <div class="content">
-                <a href="https://thibaut6.typeform.com/to/quiFdr" target="_blank">Ajouter un service</a>
+                <a href="{{ site.baseurl }}/ajouter-un-service.html">Ajouter un service</a>
               </div>
             </div>
           </div>

--- a/ajouter-un-service.md
+++ b/ajouter-un-service.md
@@ -1,0 +1,17 @@
+---
+layout: pages
+---
+# Ajouter votre service
+
+Votre service doit être un service accessible depuis Internet (un site web, une application mobile&hellip;).
+
+## Utiliser Github
+
+Si vous êtes familier avec [GitHub], vous pouvez suivre les consignes décrites dans le fichier [CONTRIBUTING.MD](https://github.com/sgmap/api.gouv.fr/blob/gh-pages/CONTRIBUTING.md) du dépot de ce site.
+
+## Nous contacter
+
+Si vous n'êtes pas familier avec [GitHub], vous pouvez nous communiquer vos coordonnées sur [contact@api.gouv.fr](mailto:contact@api.gouv.fr) afin d'être recontacté.
+
+
+[GitHub]: https://github.com/

--- a/ajouter-une-api.md
+++ b/ajouter-une-api.md
@@ -1,0 +1,42 @@
+---
+layout: pages
+---
+# Ajouter votre API
+
+Vérifier l'éligibilité de votre API en consultant les critères ci-dessous&nbsp;:
+
+## Eligibilité d'une API sur API.GOUV.fr
+
+### Finalité
+
+Etre produite et exploitée par une autorité administrative. Cela inclue les administrations de l’Etat (centralisées et décentralisées), les collectivités territoriales, les établissements publics à caractère
+administratif, les organismes gérant des régimes de protection sociale relevant du code de la sécurité sociale et du code rural ou mentionnés aux articles L. 223-16 et L.351-21 du code du travail et les autres organismes chargés de la gestion d'un service public administratif.
+
+Présenter un intérêt pour des réutilisateurs publics ou privés.
+
+### Exigences
+
+* avoir une description fonctionnelle claire et succincte de l'API à renseigner sur API.GOUV,
+* avoir une documentation technique en ligne et claire,
+* disposer d'une procédure en ligne pour demander l'accès à l'API si elle n'est pas totalement ouverte.
+
+Le critère d'acceptation principal est de pouvoir tester l'API en moins d'une journée et de l'intégrer en moins d'une semaine.
+
+### Bonnes pratiques
+
+ * fournir une documentation sous le format [OPEN API](https://openapis.org/)
+ * fournir des exemples pertinents démontrant l'utilisation de l'API
+ * fournir une page de statistiques publique exhibant les volumétries pertinentes pour l'API concernée (nombre de hits, mais surtout mesures sectorielles comme nombre de courses de taxi (le.taxi), nombre de candidatures simplifiées aux marchés publics (API Entreprise) ...
+ * décrire simplement les modalités d'accès à l'API (CGU, licence ..) et simplifier au maximum l'enrôlement
+ * avoir un environnement Bac à sable pour tester facilement l'API
+
+## Utiliser Github
+
+Si vous êtes familier avec [GitHub], vous pouvez suivre les consignes décrites dans le fichier [CONTRIBUTING.MD](https://github.com/sgmap/api.gouv.fr/blob/gh-pages/CONTRIBUTING.md) du dépot de ce site.
+
+## Nous contacter
+
+Si vous n'êtes pas familier avec [GitHub], vous pouvez nous communiquer vos coordonnées sur [contact@api.gouv.fr](mailto:contact@api.gouv.fr) afin que nous vous recontactions.
+
+
+[GitHub]: https://github.com/


### PR DESCRIPTION
Création de page pour ajouter son API et son service

Réutilisation de la page du wiki pour les [critères d'éligibilités](https://github.com/sgmap/api.gouv.fr/wiki/Eligibilite-API)

Dispo [ici](http://dev.api.gouv.fr/)