### PR TITLE
Remove unused command

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,9 +18,3 @@ test:
     - grep "css/main.css" _site/index.html # smoke test that something was actually compiled
     - bundle exec htmlproofer ./_site --assume-extension --check-html --disable-external --empty-alt-ignore
     - html5validator --root _site
-
-deployment:
-  index:
-    branch: master
-    commands:
-      - bundle exec jekyll push


### PR DESCRIPTION
`jekyll push` does not exist, failed builds.

![capture d ecran 2016-09-19 a 15 30 21](https://cloud.githubusercontent.com/assets/222463/18634192/3ee3310c-7e80-11e6-8d64-c8aa98ca091a.png)
![capture d ecran 2016-09-19 a 15 30 02](https://cloud.githubusercontent.com/assets/222463/18634194/41862946-7e80-11e6-97bd-f9f49576a5bd.png)