### PR TITLE
Menu, faire un lien vers la vraie liste des API

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
         <header>
           <nav class="ui secondary menu">
             <div class="right menu">
-              <a class="item" href="{{ site.baseurl }}/index#type">API</a>
+              <a class="item" href="{{ site.baseurl }}/api/">API</a>
               <a class="large screen only item" href="{{ site.baseurl }}/services">Services</a>
               <a class="item" id="logo" href="{{ site.baseurl }}/">api.gouv.fr</a>
             </div>


### PR DESCRIPTION
C'est pas super intuitif d'arriver sur la home, les 4 catégories d'API quand on clique dans le menu, je pense que aller vers la page qui liste les API serait mieux.