### PR TITLE
Supprimer le compteur incrémental sur l'affichage des données d'API

### DIFF
--- a/_layouts/api.html
+++ b/_layouts/api.html
@@ -163,25 +163,13 @@ layout: default
         {% if page.stat.path %}
           data = data["{{ page.stat.path | join: '"]["' }}"]
         {% endif %}
-        var step = Math.round(data / 15);
-        incrementValue(0, data, step)()
+        printStat(data)
       });
-      function incrementValue(current, max, step) {
-        return function() {
-          printStat(current)
-          step = isCounterOverflowing(current, step, max) ? max - current : step;
-          if(current < max) {
-            setTimeout(incrementValue(current + step, max, step), 60)
-          }
-        }
-      }
+
       function printStat(data) {
         $divStat.text( parseInt( data ).toLocaleString('fr-FR') );
       }
 
-      function isCounterOverflowing(current, step, max) {
-        return current + step >= max
-      }
     {% endif %}
   });
 </script>


### PR DESCRIPTION
Je trouve que le compteur actuel est un peu trop gadget et ne fait pas très sérieux.