### PR TITLE
Espacer les labels de mot-clés

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -36,6 +36,10 @@ header {
 	}
 }
 
+.ui.tiny.label {
+	margin-bottom: 2px;
+}
+
 main {
 	margin-bottom: 3em;
 }


### PR DESCRIPTION
Avant:
<img width="569" alt="screen shot 2016-11-30 at 14 56 19" src="https://cloud.githubusercontent.com/assets/1475946/20754898/519754fc-b70d-11e6-9c06-30ec9cb3a8b4.png">


Après:
<img width="570" alt="screen shot 2016-11-30 at 14 56 01" src="https://cloud.githubusercontent.com/assets/1475946/20754904/5522b846-b70d-11e6-91fb-eec12cc4a9a6.png">
